### PR TITLE
OS issue

### DIFF
--- a/R/download_dependencies.r
+++ b/R/download_dependencies.r
@@ -67,7 +67,7 @@ download_dependencies <- function(address = paste0(system.file(package="gwascell
       utils::download.file(url = "https://ctg.cncr.nl/software/MAGMA/prog/magma_v1.10_win.zip", destfile = paste0(address, "magma_v1.10_win.zip"))
       utils::unzip(paste0(address,"magma_v1.10_win.zip"), exdir = address)
     } else {
-      if (get_os() == "unix") {
+      if (get_os() == "linux") {
         utils::download.file(url = "https://ctg.cncr.nl/software/MAGMA/prog/magma_v1.10_static.zip", destfile = paste0(address, "magma_v1.10_static.zip"))
         utils::unzip(paste0(address,"magma_v1.10_static.zip"), exdir = address)
       } else {


### PR DESCRIPTION
Ran into this trying to `download_dependencies`

It may or may not make more sense to check `.Platform$OS.type`.

It'll be fixed if you use BiocFileCache or similar, but it'd be really good to check if the files exist on disk - if I try to re-run `download_dependencies` it does everything again